### PR TITLE
Limit gdb's backtrace to 1000 lines

### DIFF
--- a/gdb.rb
+++ b/gdb.rb
@@ -53,7 +53,7 @@ module GDB
       core_path = rename_core(core_path)
       unless gdb_command
         gdb_command = Tempfile.new("gdb-bt")
-        gdb_command.puts "bt"
+        gdb_command.puts "bt 1000"
         gdb_command.close
       end
       puts


### PR DESCRIPTION
gdb may generate thousands of lines: http://fbsd.rubyci.org/~chkbuild/ruby-trunk/log/20130404T110200Z.log.html.gz
