### PR TITLE
abi-checker.rb now supports --skip-symbols

### DIFF
--- a/abi-checker.rb
+++ b/abi-checker.rb
@@ -29,10 +29,7 @@
 # EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 require 'tempfile'
-
-if ARGV.size < 2 then
-  puts "usage: abi-checker path-to-old-ruby path-to-new-ruby"
-end
+require "optparse"
 
 skip_headers = <<END
 classext.h
@@ -62,6 +59,18 @@ xml_template = <<END
       {RELPATH}/lib
     </libs>
 END
+
+opts = OptionParser.new
+opts.on("--skip-symbols FILE") {|f|
+  # If --skip-symbols is specified, they are skipped too.
+  skip_symbols += File.open(f).read
+}
+opts.parse!(ARGV)
+
+if ARGV.size < 2 then
+  puts "usage: abi-checker [--skip-symbols FILE] path-to-old-ruby path-to-new-ruby"
+end
+
 
 sh_file = Tempfile.open("skip-headers")
 sh_file.write(skip_headers)


### PR DESCRIPTION
現在 rubyci.org で193ブランチがABIエラーでていますが、意図的な変更なのでエラーを非表示にする方向で対応考えています。
つきましては、abi-checkerにスキップするシンボルリストを含んだファイルを与えるオプションを追加したく思います。マージを検討いただければ幸いです。

ところで、chkbuildのしくみとして200ブランチの時は --skip-symbols skip_symbols_200, 193ブランチの時は --skip-symbols skip_symbols_193 のように引数を変更することはできますか。可能であれば193の時だけ、rb_class_init_copy を除外したいのですが。
すべてのブランチ横断でシンボルリスト共有するとあっという間に、何故追加したのか分からないシンボルが増殖しそうです。
