### PR TITLE
1.8's Regexp.union doesn't expand given array

### DIFF
--- a/chkbuild/hook.rb
+++ b/chkbuild/hook.rb
@@ -308,7 +308,7 @@ module ChkBuild
         pats2.concat pat
       }
     }
-    Regexp.union(pats1 + pats2)
+    Regexp.union(*(pats1 + pats2))
   end
 
   ChkBuild.define_failure_start_pattern(nil, nil, /timeout: output interval exceeds /)


### PR DESCRIPTION
On CentOS and old Ubuntu, system's ruby is still Ruby 1.8
