### PR TITLE
Don't escape '"', ':' and '\\'

### DIFF
--- a/escape.rb
+++ b/escape.rb
@@ -560,12 +560,11 @@ module Escape
   end
 
   def _ltsv_word(str)
-    if /[\0-\x1f":\\\x7f]/ !~ str
-      # ASCII control characters, '"', ':' and '\\' not found
+    if /[\0-\x1f\x7f]/ !~ str
+      # ASCII control characters not found
       str
     else
-      '"' +
-      str.gsub(/[\0-\x1f":\\\x7f]/) {
+      str.gsub(/[\0-\x1f\x7f]/) {
         ch = $&
         case ch
         when "\0"; '\0'
@@ -580,8 +579,7 @@ module Escape
         else
           "\\x%02X" % ch.unpack("C")[0]
         end
-      } +
-      '"'
+      }
     end
   end
 end


### PR DESCRIPTION
Standard LTSV doesn't support escaping.
Such extension breaks interoperability and is useless in this context because ASCII control characters won't appear normal conditions.
