### PR TITLE
Retry on timeout

### DIFF
--- a/chkbuild/upload.rb
+++ b/chkbuild/upload.rb
@@ -90,7 +90,7 @@ module ChkBuild
     service.with_filter do |req, _next|
       i = 0
       begin
-        return _next.call
+        next _next.call
       rescue
         case $!
         when Errno::ETIMEDOUT


### PR DESCRIPTION
Azure Storage recommends retry on failure because such cloud storage is dynamically reconfigured to adopt its huge work load, but azure-sdk-for-ruby doesn't provide default retry policy... http://azure.microsoft.com/blog/2014/05/22/azure-storage-client-library-retry-policy-recommendations/
