### PR TITLE
Avoid false positive of warning counter

### DIFF
--- a/chkbuild/hook.rb
+++ b/chkbuild/hook.rb
@@ -69,7 +69,7 @@ module ChkBuild
   ChkBuild.define_title_hook(nil, nil) {|title, logfile|
     num_warns = 0
     logfile.each_line {|line|
-      line.scan(/warn/i) {
+      line.scan(/\bwarning:/i) {
         num_warns += 1
       }
     }


### PR DESCRIPTION
Current regexp /warn/ matches too many false positive,
for example test/spec names and method names.