### PR TITLE
Extend timeout for build-ruby

### DIFF
--- a/sample/build-ruby
+++ b/sample/build-ruby
@@ -94,7 +94,7 @@ ChkBuild::Ruby.def_target(
 
   # :old => 1,
 
-  :timeout => '1h',
+  :timeout => '2h',
 
   :output_interval_timeout => '5min'
   )


### PR DESCRIPTION
[Amazon Linux 2018.03 x64](http://rubyci.s3.amazonaws.com/amazon/ruby-trunk/recent.html) and [OpenSUSE leap 42.2](http://rubyci.s3.amazonaws.com/opensuseleap/ruby-trunk/recent.html) tend to get command timeout.

To make them green, I want to extend the timeout for those machines.