### PR TITLE
Remove the false positive of warning counts

### DIFF
--- a/chkbuild/hook.rb
+++ b/chkbuild/hook.rb
@@ -69,7 +69,7 @@ module ChkBuild
   ChkBuild.define_title_hook(nil, nil) {|title, logfile|
     num_warns = 0
     logfile.each_line {|line|
-      line.scan(/\bwarning:/i) {
+      line.scan(/\bwarning:(?!:)/i) {
         num_warns += 1
       }
     }


### PR DESCRIPTION
The regexp wrongly detected:
```
class Warning::buffer [String, Comparable, Object, Kernel, BasicObject]
Warning::buffer#write -1
```