### PR TITLE
Send "QUIT" signal when killing a timeout process

### DIFF
--- a/timeoutcom.rb
+++ b/timeoutcom.rb
@@ -229,7 +229,7 @@ module TimeoutCommand
         else
           msgout.puts "timeout: #{timeout_reason}" if msgout
           begin
-            Process.kill(0, -pid)
+            Process.kill("QUIT", -pid)
             show_process_group("timeout: the process group #{pid} is alive.", pid, msgout)
             kill_processgroup(pid, msgout)
           rescue Errno::ESRCH # no process


### PR DESCRIPTION
When a process times out, kill it using the "QUIT" signal.  QUIT will
cause the process to exit but also dump a core file.  Then we can use
the core file to debug why the process is timing out.

I *think* this is all we need to get core files when a process times out.

cc @mame @junaruga 