### PR TITLE
Add one-shot build script for a specific commit

### DIFF
--- a/chkbuild/git.rb
+++ b/chkbuild/git.rb
@@ -116,6 +116,25 @@ class ChkBuild::IBuild
           end
         }
       end
+
+      if revision = opts[:revision]
+        Dir.chdir(working_dir) {
+          opts2[:section] = nil
+          command = ["git", "fetch", "-q", "origin", revision]
+          command << opts2
+          begin
+            self.run(*command)
+          rescue ChkBuild::Build::CommandError
+            try += 1
+            retry if try < 3
+            raise
+          end
+
+          command = ["git", "checkout", "-q", revision]
+          command << opts2
+          self.run(*command)
+        }
+      end
     }
     Dir.chdir(working_dir) {
       new_head = git_head_commit

--- a/chkbuild/lock.rb
+++ b/chkbuild/lock.rb
@@ -32,10 +32,10 @@ module ChkBuild
   LOCK_PATH = ChkBuild.build_top + '.lock'
 
   # If true, wait until another chkbuild process finishes.
-  @wait_for_lock = false
+  @wait_in_progress_builds = false
 
   class << self
-    attr_accessor :wait_for_lock
+    attr_accessor :wait_in_progress_builds
   end
 
   def self.lock_start
@@ -43,7 +43,7 @@ module ChkBuild
       @lock_io = LOCK_PATH.open(File::WRONLY|File::CREAT|File::APPEND)
     end
     lock_op = File::LOCK_EX
-    lock_op |= File::LOCK_NB unless @wait_for_lock
+    lock_op |= File::LOCK_NB unless @wait_in_progress_builds
     if @lock_io.flock(lock_op) == false
       raise "another chkbuild is running."
     end

--- a/chkbuild/lock.rb
+++ b/chkbuild/lock.rb
@@ -31,11 +31,20 @@
 module ChkBuild
   LOCK_PATH = ChkBuild.build_top + '.lock'
 
+  # If true, wait until another chkbuild process finishes.
+  @wait_for_lock = false
+
+  class << self
+    attr_accessor :wait_for_lock
+  end
+
   def self.lock_start
     if !defined?(@lock_io)
       @lock_io = LOCK_PATH.open(File::WRONLY|File::CREAT|File::APPEND)
     end
-    if @lock_io.flock(File::LOCK_EX|File::LOCK_NB) == false
+    lock_op = File::LOCK_EX
+    lock_op |= File::LOCK_NB unless @wait_for_lock
+    if @lock_io.flock(lock_op) == false
       raise "another chkbuild is running."
     end
     if 102400 < @lock_io.stat.size

--- a/chkbuild/ruby.rb
+++ b/chkbuild/ruby.rb
@@ -348,7 +348,12 @@ def (ChkBuild::Ruby).build_proc(b)
     svn_info_section = b.logfile.get_section('svn-info/ruby')
     ruby_rev = svn_info_section[/Last Changed Rev: (\d+)/, 1].to_i
   else
-    b.git("https://github.com/ruby/ruby", 'ruby', {:git_fetch_refspec => "refs/notes/commits:refs/notes/commits"}.update(bopts))
+    git_opts = bopts.dup
+    git_opts[:git_fetch_refspec] = "refs/notes/commits:refs/notes/commits"
+    if rev = bopts[:ruby_revision]
+      git_opts[:revision] = rev
+    end
+    b.git("https://github.com/ruby/ruby", 'ruby', git_opts)
     ruby_rev = Dir.chdir('ruby') {b.git_head_commit[0..10]}
   end
 

--- a/start-oneshot-rubyci
+++ b/start-oneshot-rubyci
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+# start-oneshot-rubyci - Start RubyCI for a specific commit
+#
+# Usage:
+#   start-oneshot-rubyci <commit> [-D] [chkbuild-args...]
+#
+# Options:
+#   -D: Start chkbuild in foreground
+#
+# Example:
+#   start-oneshot-rubyci 6b3e6b1 build ruby-master-oneshot
+
+$:.unshift File.dirname(File.expand_path(__FILE__))
+
+require "rbconfig"
+require "chkbuild"
+
+rev = ARGV.shift
+if rev.nil?
+  abort "Usage: #$0 <commit>"
+end
+daemon = !ARGV.delete("-D")
+
+cmd = [RbConfig.ruby, "#{__dir__}/start-rubyci", *ARGV]
+if ARGV.empty?
+  # Build the given commit with master branch build configuration
+  cmd.push "build", "ruby-master-oneshot"
+end
+
+Dir.chdir(__dir__) do
+  $stderr.puts "Starting RubyCI for #{rev} in #{daemon ? "foreground" : "background"}..."
+  Process.daemon(true) if daemon
+  # Spawn a new chkbuild process instead of in-process because
+  # `ChkBuild.main_build` invokes `$0` to start a internal build process.
+  system({ "RUBYCI_ONESHOT_BUILD_COMMIT" => rev }, *cmd, exception: true)
+end

--- a/start-rubyci
+++ b/start-rubyci
@@ -57,6 +57,10 @@ ChkBuild.nickname = ENV["RUBYCI_NICKNAME"] if ENV["RUBYCI_NICKNAME"]
 # ChkBuild.top_uri = "file://#{ChkBuild.public_top}/"
 # ChkBuild.top_uri = nil # use relative URL
 
+# Oneshot commit build is not triggered periodically, so wait until
+# other builds are finished.
+ChkBuild.wait_for_lock = true if ENV["RUBYCI_ONESHOT_BUILD_COMMIT"]
+
 #ChkBuild.azure_upload_target rescue nil
 ChkBuild.s3_upload_target
 arg = [].push(
@@ -64,6 +68,9 @@ arg = [].push(
     { :suffix_? => 'master', :output_interval_timeout => '30min' },
     *ChkBuild::Ruby.maintained_release_branches
   ],
+  if commit = ENV["RUBYCI_ONESHOT_BUILD_COMMIT"]
+    { :suffix_? => 'oneshot', :ruby_revision => commit }
+  end,
 
 #   [ # :abi_check needs --enable-shared
 #     { :suffix_? => 'trunk', :abi_check_notitle => '/home/akr/ruby/200p0', :output_interval_timeout => '10min' },

--- a/start-rubyci
+++ b/start-rubyci
@@ -59,7 +59,7 @@ ChkBuild.nickname = ENV["RUBYCI_NICKNAME"] if ENV["RUBYCI_NICKNAME"]
 
 # Oneshot commit build is not triggered periodically, so wait until
 # other builds are finished.
-ChkBuild.wait_for_lock = true if ENV["RUBYCI_ONESHOT_BUILD_COMMIT"]
+ChkBuild.wait_in_progress_builds = true if ENV["RUBYCI_ONESHOT_BUILD_COMMIT"]
 
 #ChkBuild.azure_upload_target rescue nil
 ChkBuild.s3_upload_target


### PR DESCRIPTION
This PR introduces a one-shot build for a specific git commit. At this moment, only those who can ssh into runner machines can trigger builds by:

```console
$ ssh <host> /path/to/start-oneshot-rubyci c286e0f0255837ebe03b0dd9eb6d4e6821df8f79
```