### PR TITLE
Pass the --with-dump-ast option to Ruby build

### DIFF
--- a/sample/build-crossruby
+++ b/sample/build-crossruby
@@ -297,6 +297,8 @@ ChkBuild.define_build_proc('crossruby') {|b|
     configure_args << "--build=#{build_system}" if build_system
     configure_args << "--host=#{target_system}"
     configure_args << "--with-baseruby=#{baseruby}"
+    dump_ast = "#{nativeruby_build.dir}/ruby/dump_ast"
+    configure_args << "--with-dump-ast=#{dump_ast}" if File.exist?(dump_ast)
     configure_args << "--disable-install-doc"
     b.run('./configure', *configure_args)
     show_verconf_h(b)

--- a/start-cross-rubyci
+++ b/start-cross-rubyci
@@ -211,6 +211,8 @@ ChkBuild.define_build_proc('crossruby') {|b|
     configure_args << "--build=#{build_system}" if build_system
     configure_args << "--host=#{target_system}"
     configure_args << "--with-baseruby=#{baseruby}"
+    dump_ast = "#{nativeruby_build.dir}/ruby/dump_ast"
+    configure_args << "--with-dump-ast=#{dump_ast}" if File.exist?(dump_ast)
     configure_args << "--disable-install-doc"
     configure_args.concat b.opts[:configure_args] if b.opts[:configure_args]
     b.run('./configure', *configure_args)


### PR DESCRIPTION
Building builtins now requires a built dump-ast script, which is used for parsing source files. It was previously being compiled with $(CC), which doesn't work for crossbuild. Instead, the opt-out mechanism is to explicitly pass a --with-dump-ast path.