### PR TITLE
Fix infinite log growth when formatting with Ruby 3.4

### DIFF
--- a/chkbuild/ibuild.rb
+++ b/chkbuild/ibuild.rb
@@ -433,7 +433,7 @@ class ChkBuild::IBuild # internal build
   end
 
   def script_to_run_in_child(opts, command, alt_commands, *args)
-    ruby_script = ''
+    ruby_script = String.new
     opts.each {|k, v|
       next if /\AENV:/ !~ k.to_s
       k = $'

--- a/chkbuild/iformat.rb
+++ b/chkbuild/iformat.rb
@@ -534,7 +534,7 @@ End
 
   def markup_log_line(line)
     line = encode_invalid(line)
-    result = ''
+    result = String.new
     if /\A== (\S+)/ =~ line
       tag = $1
       rest = $'
@@ -547,7 +547,7 @@ End
 
   def markup_fail_line(line)
     line = encode_invalid(line)
-    result = ''
+    result = String.new
     if /\A== (\S+)/ =~ line
       tag = $1
       rest = $'
@@ -566,14 +566,14 @@ End
       url = $2
       "<a href=#{ha url}>#{h content.strip}</a>"
     else
-      result = ''
+      result = String.new
       markup_uri(line, result)
       result
     end
   end
 
   def markup_diff(str)
-    result = ''
+    result = String.new
     str.each_line {|line|
       result << markup_diff_line(line)
     }

--- a/chkbuild/iformat.rb
+++ b/chkbuild/iformat.rb
@@ -140,6 +140,11 @@ class ChkBuild::IFormat # internal format
         }
       else
         open(@filename) {|f|
+          # STDOUT/STDERR may be redirected to this file while reading it.
+          # Stop at the size at open to avoid reading lines appended by
+          # this process itself, such as warnings emitted per line.
+          # https://github.com/ruby/chkbuild/issues/77
+          stop = f.stat.size
           f.each_line {|line|
             line.force_encoding("ascii-8bit") if line.respond_to? :force_encoding
             if /\A\s*\z/ =~ line
@@ -149,6 +154,7 @@ class ChkBuild::IFormat # internal format
               empty_lines = []
               yield line
             end
+            break if stop <= f.pos
           }
         }
       end

--- a/chkbuild/logfile.rb
+++ b/chkbuild/logfile.rb
@@ -63,7 +63,7 @@ class ChkBuild::LogFile
       when /\A7\.0/; codename = 'wheezy'
       else codename = nil
       end
-      rel = ''
+      rel = String.new
       rel << "Distributor ID:\tDebian\n"
       rel << "Description:\tDebian GNU/Linux #{ver}"
       rel << " (#{codename})" if codename

--- a/chkbuild/ruby.rb
+++ b/chkbuild/ruby.rb
@@ -895,7 +895,7 @@ ChkBuild.define_title_hook('ruby', "abi-check") {|title, log|
   #low = 0
   #log.scan(/ Low +([0-9])+ *$/) { low += $1.to_i }
   if high != 0 || medium != 0 # || low != 0
-    str = "ABI:"
+    str = String.new("ABI:")
     str << "#{high}H" if high != 0
     str << "#{medium}M" if medium != 0
     #str << "#{low}L" if low != 0
@@ -916,7 +916,7 @@ ChkBuild.define_title_hook('ruby', nil) {|title, logfile|
     numsigabrt += line.scan(/chkbuild: signal SIGABRT/i).length
     numfatal += line.scan(/\[FATAL\]/i).length
   }
-  mark = ''
+  mark = String.new
   mark << " #{numbugs == 1 ? '' : numbugs}[BUG]" if 0 < numbugs
   mark << " #{numsegv == 1 ? '' : numsegv}[SEGV]" if 0 < numsegv
   mark << " #{numsigbus == 1 ? '' : numsigbus}[SIGBUS]" if 0 < numsigbus

--- a/escape.rb
+++ b/escape.rb
@@ -112,7 +112,7 @@ module Escape
     elsif %r{\A[0-9A-Za-z+,./:=@_-]+\z} =~ str
       ShellEscaped.new(str)
     else
-      result = ''
+      result = String.new
       str.scan(/('+)|[^']+/) {
         if $1
           result << %q{\'} * $1.length
@@ -276,7 +276,7 @@ module Escape
   #
   # See HTML 4.01 for details.
   def html_form(pairs, sep='&')
-    r = ''
+    r = String.new
     first = true
     pairs.each {|k, v|
       # query-chars - pct-encoded - x-www-form-urlencoded-delimiters =
@@ -548,7 +548,7 @@ module Escape
   end
 
   def ltsv_line(assoc)
-    result = ''
+    result = String.new
     assoc.each {|k, v|
       result << _ltsv_key(k)
       result << ':'

--- a/timeoutcom.rb
+++ b/timeoutcom.rb
@@ -110,7 +110,7 @@ module TimeoutCommand
 
   def show_process_group(msg, pgid, msgout)
     return if !msgout
-    msgbuf = ''
+    msgbuf = String.new
     # ps -A and -o option is defined by POSIX.
     # However MirOS BSD (MirBSD 10 GENERIC#1382 i386) don't have -A and -ax can be used instead.
     #
@@ -123,7 +123,7 @@ module TimeoutCommand
     when /\bmirbsd/
       ps_all_process_option = '-ax'
     end
-    ps_additional_options = ''
+    ps_additional_options = String.new
     case RUBY_PLATFORM
     when /\blinux\b/
       ps_additional_options << ' -L' # show threads


### PR DESCRIPTION
Under Ruby 3.4 mutating a chilled string literal emits "literal string will be frozen in the future". The format process redirects stderr to the log file it is reading, so `markup_log_line` emitted one warning per line into the same file and `LineReader` never reached EOF, growing `current.txt` and `last.txt` beyond 60GB.

This replaces the mutated string literals with `String.new` and makes `LineReader` stop at the file size observed at open, so any future per-line warning cannot feed back into the read loop.

Fixes https://github.com/ruby/chkbuild/issues/77

Generated with [Claude Code](https://claude.com/claude-code)
